### PR TITLE
Update task 7 for SOFE

### DIFF
--- a/tasks/task7.ipynb
+++ b/tasks/task7.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,17 +68,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{-6: ['tungsten'], -7: ['cu'], -8: ['cucrzr'], -9: ['top_surface'], -10: ['cooling_surface'], -11: ['poloidal_gap'], -12: ['toroidal_gap'], -13: ['bottom']}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "correspondance_dict, cell_data_types = convert_med_to_xdmf(\"task7/mesh.med\", cell_file=\"task7/mesh_domains.xdmf\", facet_file=\"task7/mesh_boundaries.xdmf\")\n",
     "\n",
@@ -87,17 +79,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Succesfully load mesh with 106966 cells\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import festim as F\n",
     "\n",
@@ -121,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
For this task as the CAD files wont be able to be converted to a mesh within the codespace environment without SALOME, however we could provide an example script for how this may be done once salome is installed locally?

Furthermore, for the H transport, for the workshop i'm guessing we should only run a steady state simulation for the 3D case, not sure how long the sims take to run. Otherwise we could provide a mesh for a 2D slice and run a simple transient sim on that?

However we will likely have to have GIFs and images of the XDMF outputs too

what do you think @RemDelaporteMathurin ?